### PR TITLE
Metric alignment across executor types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,23 @@
  * and limitations under the License.
  * =========================================================================================
  */
+scalaVersion := "2.11.0"
+
+crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0")
 
 resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
-val kamonCore    = "io.kamon" %% "kamon-core"    % "1.0.0-RC2-ead4fd7743895ffe1d34e37c23eceab575fb907e"
-val kamonTestkit = "io.kamon" %% "kamon-testkit" % "1.0.0-RC2-ead4fd7743895ffe1d34e37c23eceab575fb907e"
+val kamonCore    = "io.kamon" %% "kamon-core"    % "1.0.0-RC3"
+val kamonTestkit = "io.kamon" %% "kamon-testkit" % "1.0.0-RC3"
+val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
 
 lazy val root = (project in file("."))
   .settings(name := "kamon-executors")
+  .settings(aspectJSettings: _*)
   .settings(
       libraryDependencies ++=
-        compileScope(kamonCore) ++
-        testScope(scalatest, logbackClassic, kamonTestkit))
+      compileScope(kamonCore, logback) ++
+      testScope(scalatest, logbackClassic, kamonTestkit) ++
+      providedScope(aspectJ)
+  )
+
+fork := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 lazy val root: Project = project.in(file(".")).dependsOn(latestSbtUmbrella)
 lazy val latestSbtUmbrella = uri("git://github.com/kamon-io/kamon-sbt-umbrella.git")
+

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+kamon.executors.sample-interval = 1ms

--- a/src/test/scala/kamon/executors/ExecutorMetricsSpec.scala
+++ b/src/test/scala/kamon/executors/ExecutorMetricsSpec.scala
@@ -17,14 +17,46 @@
 
 package kamon.executors
 
+import java.util.UUID
+
 import kamon.testkit.MetricInspection
 import org.scalatest.{Matchers, WordSpec}
-import java.util.concurrent.{Executors => JavaExecutors}
+import java.util.concurrent.{ExecutorService, ForkJoinPool, ThreadPoolExecutor, Executors => JavaExecutors}
 
-import scala.concurrent.forkjoin.{ForkJoinPool => ScalaForkJoinPool}
+import kamon.util.Registration
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Span}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, Promise}
 
 
-class ExecutorMetricsSpec extends WordSpec with Matchers with MetricInspection {
+class ExecutorMetricsSpec extends WordSpec with Matchers with MetricInspection with Eventually {
+
+
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = scaled(Span(2000, Millis)), interval = scaled(Span(20, Millis)))
+
+  class ExecutorMetrics(name: String, tpe: String) {
+    private val poolTags = Map(
+      "name" -> name,
+      "type" -> tpe
+    )
+    def poolMin(reset: Boolean = false) = Metrics.Pool.refine(poolTags + ("setting" -> "min")).value(reset)
+    def poolMax(reset: Boolean = false) = Metrics.Pool.refine(poolTags + ("setting" -> "max")).value(reset)
+
+    def threadsTotal(reset: Boolean = false) = Metrics.Threads.refine(poolTags + ("state" -> "total")).distribution(reset)
+    def threadsActive(reset: Boolean = false) = Metrics.Threads.refine(poolTags + ("state" -> "active")).distribution(reset)
+
+    def tasksSubmitted(reset: Boolean = false) = Metrics.Tasks.refine(poolTags + ("state" -> "submitted")).value(reset)
+    def tasksCompleted(reset: Boolean = false) = Metrics.Tasks.refine(poolTags + ("state" -> "completed")).value(reset)
+
+    def queue(reset: Boolean = false) = Metrics.Queue.refine(poolTags).distribution(reset)
+
+    def poolParallelism(reset: Boolean = false) = Metrics.Pool.refine(poolTags + ("setting" -> "parallelism")).value(reset)
+
+    def poolCoreSize(reset: Boolean = false) = Metrics.Pool.refine(poolTags + ("setting" ->  "corePoolSize")).value(reset)
+  }
 
   "the ExecutorServiceMetrics" should {
     "register a SingleThreadPool, collect their metrics and remove it" in {
@@ -32,6 +64,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with MetricInspection {
       val registeredPool = Executors.register("single-thread-pool", singleThreadPoolExecutor)
 
       Metrics.Threads.valuesForTag("name")  should contain ("single-thread-pool")
+      Metrics.Threads.valuesForTag("type")  should contain ("tpe")
 
       registeredPool.cancel()
     }
@@ -41,6 +74,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with MetricInspection {
       val registeredPool = Executors.register("thread-pool-executor", threadPoolExecutor)
 
       Metrics.Threads.valuesForTag("name")  should contain ("thread-pool-executor")
+      Metrics.Threads.valuesForTag("type")  should contain ("tpe")
 
       registeredPool.cancel()
     }
@@ -50,26 +84,168 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with MetricInspection {
       val registeredPool = Executors.register("scheduled-thread-pool-executor", scheduledThreadPoolExecutor)
 
       Metrics.Threads.valuesForTag("name")  should contain ("scheduled-thread-pool-executor")
+      Metrics.Threads.valuesForTag("type")  should contain ("tpe")
 
       registeredPool.cancel()
     }
 
-    "register a Java ForkJoinPool, collect their metrics and remove it" in {
-      val javaForkJoinPool = JavaExecutors.newWorkStealingPool()
+    "register a ForkJoinPool, collect their metrics and remove it" in {
+      val javaForkJoinPool = Executors.instrument(JavaExecutors.newWorkStealingPool())
       val registeredForkJoin = Executors.register("java-fork-join-pool", javaForkJoinPool)
 
       Metrics.Threads.valuesForTag("name")  should contain ("java-fork-join-pool")
+      Metrics.Threads.valuesForTag("type")  should contain ("fjp")
 
       registeredForkJoin.cancel()
     }
 
     "register a Scala ForkJoinPool, collect their metrics and remove it" in {
-      val scalaForkJoinPool = new ScalaForkJoinPool()
+      val scalaForkJoinPool = Executors.instrument(new scala.concurrent.forkjoin.ForkJoinPool(10))
       val registeredForkJoin = Executors.register("scala-fork-join-pool", scalaForkJoinPool)
 
       Metrics.Threads.valuesForTag("name")  should contain ("scala-fork-join-pool")
+      Metrics.Threads.valuesForTag("type")  should contain ("fjp")
 
       registeredForkJoin.cancel()
     }
+
   }
+
+  def setupTestPool(executor: ExecutorService): (ExecutorService, ExecutorMetrics, Registration) = {
+    val typeTag = executor match {
+      case javaFjp:ForkJoinPool                             => "fjp"
+      case scalaFjp: scala.concurrent.forkjoin.ForkJoinPool => "fjp"
+      case tpe:ThreadPoolExecutor                           => "tpe"
+    }
+    val pool = Executors.instrument(executor)
+    val name = s"testExecutor-${UUID.randomUUID()}"
+    val registered = Executors.register(name, pool)
+    val metrics = new ExecutorMetrics(name, typeTag)
+    (pool, metrics, registered)
+  }
+
+
+
+  def commonExecutorMetrics(executor: Int => ExecutorService, size: Int) = {
+    "track settings" in {
+      val (pool, metrics, registration) = setupTestPool(executor(size))
+      eventually(metrics.poolMax() should be (size))
+      registration.cancel()
+    }
+
+    "track tasks" in {
+      val (pool, metrics, registration) = setupTestPool(executor(size))
+      val semaphore = Promise[String]()
+
+      eventually {
+        metrics.tasksSubmitted()      should be (0)
+        metrics.tasksCompleted()      should be (0)
+      }
+
+      val blockedTask = new Runnable {
+        override def run(): Unit = {
+          Await.result(semaphore.future, Duration.Inf)
+          ()
+        }}
+
+      pool.submit(blockedTask)
+      eventually {
+        (metrics.tasksSubmitted(), metrics.tasksCompleted()) should be (1, 0)
+      }
+
+      semaphore.success("done")
+      eventually {
+        (metrics.tasksSubmitted(), metrics.tasksCompleted()) should be (1, 1)
+      }
+
+      (1 to 10).foreach(_ => pool.submit(blockedTask))
+      eventually {
+        (metrics.tasksSubmitted(), metrics.tasksCompleted()) should be (11, 11)
+      }
+      registration.cancel()
+    }
+
+    "track threads" in {
+      val (pool, metrics, registration) = setupTestPool(executor(2))
+
+      eventually {
+        metrics.threadsTotal().max should be (0)
+        metrics.threadsActive().max should be (0)
+      }
+
+      Future(
+        (1 to 10000).foreach(_ => pool.submit(new Runnable {
+          override def run(): Unit = Thread.sleep(1)
+        }))
+      )(scala.concurrent.ExecutionContext.global)
+
+      eventually {
+        metrics.threadsActive().max should be (2)
+        metrics.threadsTotal().max should be (2)
+      }
+      registration.cancel()
+    }
+
+    "track queue" in {
+      val (pool, metrics, registration) = setupTestPool(executor(size))
+
+      val semaphore = Promise[String]()
+      val blockedTask = new Runnable {
+        override def run(): Unit = {
+          Await.result(semaphore.future, Duration.Inf)
+          ()
+        }}
+
+      eventually(metrics.queue().max should be (0))
+
+      (1 to 100).foreach(_ => pool.submit(blockedTask))
+
+      pool.submit(blockedTask)
+      eventually {
+        val queue = metrics.queue().max
+        val activeThreads = metrics.threadsActive().max
+        metrics.queue().max should be >= (100 - activeThreads)
+      }
+
+      registration.cancel()
+    }
+  }
+
+  def fjpMetrics(executor: Int => ExecutorService, size: Int) = {
+    val (pool, metrics, registration) = setupTestPool(executor(size))
+    "track FJP specific matrics" in {
+      eventually {
+        metrics.poolParallelism() should be (size)
+        metrics.poolMin() should be (0)
+      }
+      registration.cancel()
+    }
+  }
+  def tpeMetrics(executor: Int => ExecutorService, size: Int) = {
+    val (pool, metrics, registration) = setupTestPool(executor(size))
+    "track TPE specific matrics" in {
+      eventually {
+        metrics.poolCoreSize() should be (size)
+        metrics.poolMin() should be (size)
+        registration.cancel()
+
+      }
+    }
+  }
+
+  "Executor service" when {
+    "backed by Java FJP" should {
+      behave like commonExecutorMetrics(JavaExecutors.newWorkStealingPool(_), 10)
+      behave like fjpMetrics(JavaExecutors.newWorkStealingPool(_), 1)
+    }
+    "backed by Scala FJP" should {
+      behave like commonExecutorMetrics(new scala.concurrent.forkjoin.ForkJoinPool(_), 10)
+    }
+    "backed by TPE" should {
+      behave like commonExecutorMetrics(JavaExecutors.newFixedThreadPool(_), 10)
+      behave like tpeMetrics(JavaExecutors.newFixedThreadPool(_), 10)
+    }
+  }
+
 }
+


### PR DESCRIPTION
- Extract ForkJoinPoolMetrics so external executors can be sampled (ex. akka.fjp in akka 2.5)
- Common set of metrics for both TPE and FJP