### PR TITLE
allow instrumenting scheduled executors, fixes #15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,8 +68,8 @@ def groupByExperimental(tests: Seq[TestDefinition], kanelaJar: File): Seq[Group]
   val experimentalGroup = Group("experimentalTests", experimental, SubProcess(
     ForkOptions().withRunJVMOptions(Vector(
       "-javaagent:" + kanelaJar.toString,
-      "-Dkanela.modules.executors.enabled=false",
-      "-Dkanela.modules.executors-capture-on-submit.enabled=true"
+      "-Dkanela.modules.executor-service.enabled=false",
+      "-Dkanela.modules.executor-service-capture-on-submit.enabled=true"
     ))
   ))
 

--- a/kamon-executors/src/main/resources/reference.conf
+++ b/kamon-executors/src/main/resources/reference.conf
@@ -21,9 +21,7 @@ kanela.modules {
       "kamon.instrumentation.executor.ExecutorTaskInstrumentation"
     ]
 
-    within = [
-      ".*"
-    ]
+    within = [ ]
 
     exclude = [
       "^java.*",
@@ -58,13 +56,9 @@ kanela.modules {
     }
 
     within = [
-      "com.google.common.util.concurrent..*",
       "java.util.concurrent..*",
-      "scala.concurrent..*",
-      "scala.concurrent.impl..*"
-      "scala.concurrent.forkjoin.ForkJoinPool",
-      "akka.actor..*",
-      "play.api.libs.streams..*",
+      "com.google.common.util.concurrent..*",
+      "scala.concurrent.forkjoin.ForkJoinPool"
     ]
   }
 }

--- a/kamon-executors/src/main/scala/kamon/instrumentation/executor/ExecutorMetrics.scala
+++ b/kamon-executors/src/main/scala/kamon/instrumentation/executor/ExecutorMetrics.scala
@@ -69,7 +69,7 @@ object ExecutorMetrics {
   /**
     * Instruments required to track the behavior of a Thread Pool Executor Service.
     */
-  class ThreadPoolInstruments(name: String, extraTags: TagSet, executorType: String = "tpe")
+  class ThreadPoolInstruments(name: String, extraTags: TagSet, executorType: String = "ThreadPoolExecutor")
       extends InstrumentGroup(extraTags.withTag("name", name).withTag("type", executorType)) {
 
     val poolMin = register(MinThreads)
@@ -86,7 +86,7 @@ object ExecutorMetrics {
     * Instruments required to track the behavior of a Fork-Join Pool Executor Service.
     */
   class ForkJoinPoolInstruments(name: String, extraTags: TagSet)
-      extends ThreadPoolInstruments(name, extraTags, executorType = "fjp") {
+      extends ThreadPoolInstruments(name, extraTags, executorType = "ForkJoinPool") {
 
     val parallelism = register(Parallelism)
   }

--- a/kamon-executors/src/test/resources/application.conf
+++ b/kamon-executors/src/test/resources/application.conf
@@ -1,4 +1,19 @@
-kamon.executors.sample-interval = 1ms
-kanela.modules.executors {
-  exclude += "^kamon.instrumentation.executor.*"
+kamon.instrumentation.executor.sample-interval = 1ms
+
+kanela.modules {
+  executor-service {
+    exclude += "^kamon.instrumentation.executor.*"
+  }
+
+  executor-service-capture-on-submit {
+    within = ${?kanela.modules.executor-service-capture-on-submit.within} [
+      "com.google.common.util.concurrent..*",
+      "java.util.concurrent..*",
+      "scala.concurrent..*",
+      "scala.concurrent.impl..*"
+      "scala.concurrent.forkjoin.ForkJoinPool",
+      "akka.actor..*",
+      "play.api.libs.streams..*",
+    ]
+  }
 }

--- a/kamon-executors/src/test/scala/kamon/instrumentation/executor/ExecutorMetricsSpec.scala
+++ b/kamon-executors/src/test/scala/kamon/instrumentation/executor/ExecutorMetricsSpec.scala
@@ -42,7 +42,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with InstrumentInspecti
       val registeredPool = ExecutorInstrumentation.instrument(singleThreadPoolExecutor, "single-thread-pool-metrics")
 
       ExecutorMetrics.ThreadsActive.tagValues("name")  should contain ("single-thread-pool-metrics")
-      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("tpe")
+      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("ThreadPoolExecutor")
 
       registeredPool.shutdown()
     }
@@ -52,7 +52,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with InstrumentInspecti
       val registeredPool = ExecutorInstrumentation.instrument(threadPoolExecutor, "thread-pool-executor-metrics")
 
       ExecutorMetrics.ThreadsActive.tagValues("name")  should contain ("thread-pool-executor-metrics")
-      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("tpe")
+      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("ThreadPoolExecutor")
 
       registeredPool.shutdown()
     }
@@ -62,7 +62,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with InstrumentInspecti
       val registeredPool = ExecutorInstrumentation.instrument(scheduledThreadPoolExecutor, "scheduled-thread-pool-executor-metrics")
 
       ExecutorMetrics.ThreadsActive.tagValues("name")  should contain ("scheduled-thread-pool-executor-metrics")
-      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("tpe")
+      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("ThreadPoolExecutor")
 
       registeredPool.shutdown()
     }
@@ -72,7 +72,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with InstrumentInspecti
       val registeredForkJoin = ExecutorInstrumentation.instrument(javaForkJoinPool, "java-fork-join-pool-metrics")
 
       ExecutorMetrics.ThreadsActive.tagValues("name")  should contain ("java-fork-join-pool-metrics")
-      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("fjp")
+      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("ForkJoinPool")
 
       registeredForkJoin.shutdown()
     }
@@ -82,7 +82,7 @@ class ExecutorMetricsSpec extends WordSpec with Matchers with InstrumentInspecti
       val registeredForkJoin = ExecutorInstrumentation.instrument(scalaForkJoinPool, "scala-fork-join-pool-metrics")
 
       ExecutorMetrics.ThreadsActive.tagValues("name")  should contain ("scala-fork-join-pool-metrics")
-      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("fjp")
+      ExecutorMetrics.ThreadsActive.tagValues("type")  should contain ("ForkJoinPool")
 
       registeredForkJoin.shutdown()
     }

--- a/kamon-executors/src/test/scala/kamon/instrumentation/executor/ExecutorsRegistrationSpec.scala
+++ b/kamon-executors/src/test/scala/kamon/instrumentation/executor/ExecutorsRegistrationSpec.scala
@@ -18,6 +18,8 @@ package kamon.instrumentation.executor
 import java.util.concurrent.{Executors => JavaExecutors, ForkJoinPool => JavaForkJoinPool}
 
 import kamon.instrumentation.executor.ExecutorMetrics._
+import kamon.tag.TagSet
+import kamon.tag.Lookups.coerce
 import kamon.testkit.MetricInspection
 import org.scalatest.{Matchers, WordSpec}
 
@@ -32,6 +34,7 @@ class ExecutorsRegistrationSpec extends WordSpec with Matchers with MetricInspec
       val registeredScheduled = ExecutorInstrumentation.instrument(JavaExecutors.newScheduledThreadPool(1), "scheduled-thread-pool")
       val registeredSingle = ExecutorInstrumentation.instrument(JavaExecutors.newSingleThreadExecutor(), "single-thread-pool")
       val registeredSingleScheduled = ExecutorInstrumentation.instrument(JavaExecutors.newSingleThreadScheduledExecutor(), "single-scheduled-thread-pool")
+      val registeredSingleAsScheduled = ExecutorInstrumentation.instrumentScheduledExecutor(JavaExecutors.newSingleThreadScheduledExecutor(), "single-scheduled-thread-pool-as-scheduled")
       val registeredUThreadPool = ExecutorInstrumentation.instrument(JavaExecutors.unconfigurableExecutorService(JavaExecutors.newFixedThreadPool(1)), "unconfigurable-thread-pool")
       val registeredUScheduled = ExecutorInstrumentation.instrument(JavaExecutors.unconfigurableScheduledExecutorService(JavaExecutors.newScheduledThreadPool(1)), "unconfigurable-scheduled-thread-pool")
       val registeredExecContext = ExecutorInstrumentation.instrumentExecutionContext(ExecutionContext.fromExecutorService(JavaExecutors.newFixedThreadPool(1)), "execution-context")
@@ -40,11 +43,18 @@ class ExecutorsRegistrationSpec extends WordSpec with Matchers with MetricInspec
       assertContainsAllExecutorNames(TasksSubmitted.tagValues("name"))
       assertContainsAllExecutorNames(QueueSize.tagValues("name"))
 
+      val (scheduledPoolOne, _) = ThreadsActive.instruments(TagSet.of("name", "single-scheduled-thread-pool")).head
+      val (scheduledPoolTwo, _) = ThreadsActive.instruments(TagSet.of("name", "single-scheduled-thread-pool-as-scheduled")).head
+
+      scheduledPoolOne.get(coerce("type")) shouldBe "ThreadPoolExecutor"
+      scheduledPoolTwo.get(coerce("type")) shouldBe "ScheduledThreadPoolExecutor"
+
       registeredForkJoin.shutdown()
       registeredThreadPool.shutdown()
       registeredScheduled.shutdown()
       registeredSingle.shutdown()
       registeredSingleScheduled.shutdown()
+      registeredSingleAsScheduled.shutdown()
       registeredUThreadPool.shutdown()
       registeredUScheduled.shutdown()
       registeredExecContext.shutdown()
@@ -63,6 +73,7 @@ class ExecutorsRegistrationSpec extends WordSpec with Matchers with MetricInspec
       "scheduled-thread-pool",
       "single-thread-pool",
       "single-scheduled-thread-pool",
+      "single-scheduled-thread-pool-as-scheduled",
       "unconfigurable-thread-pool",
       "unconfigurable-scheduled-thread-pool",
       "execution-context"
@@ -76,6 +87,7 @@ class ExecutorsRegistrationSpec extends WordSpec with Matchers with MetricInspec
       "scheduled-thread-pool",
       "single-thread-pool",
       "single-scheduled-thread-pool",
+      "single-scheduled-thread-pool-as-scheduled",
       "unconfigurable-thread-pool",
       "unconfigurable-scheduled-thread-pool",
       "execution-context"


### PR DESCRIPTION
This PR adds a `instrumentScheduledExecutor` method that returns an `ScheduledExecutorService` instance instead of the plain `ExecutorService` returned by the `instrument` method. For now, this can only work with a `ScheduledThreadPoolExecutor` and there are a few considerations:
- It will not track the time-in-queue metric. This is motivated by the fact that some tasks might be sitting there for the whole lifetime of the application.
- It will not even offer the option of doing manual context propagation on submit since settings are not exposed at all for scheduled executors.

I'm also changing the default includes/excludes, mostly because of unintended instrumentation that ends up harming rather than helping. There is more info here: https://gitter.im/kamon-io/Kamon?at=5d2d9faa7dbfff3242b939d4 (it seems like it _is_ possible to instrument too much :joy:)