### PR TITLE
Expose wrapped thread pools

### DIFF
--- a/kamon-executors/src/main/scala/kamon/instrumentation/executor/ExecutorInstrumentation.scala
+++ b/kamon-executors/src/main/scala/kamon/instrumentation/executor/ExecutorInstrumentation.scala
@@ -11,6 +11,7 @@ import kamon.metric.Counter
 import kamon.tag.TagSet
 import org.slf4j.LoggerFactory
 
+import scala.beans.BeanProperty
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.Try
 
@@ -310,7 +311,7 @@ object ExecutorInstrumentation {
     *
     * The instruments used to track the pool's behavior are removed once the pool is shut down.
     */
-  class InstrumentedThreadPool(wrapped: ThreadPoolExecutor, name: String, extraTags: TagSet, settings: Settings)
+  class InstrumentedThreadPool(@BeanProperty val wrapped: ThreadPoolExecutor, name: String, extraTags: TagSet, settings: Settings)
       extends ExecutorService {
 
     private val _runableWrapper = buildRunnableWrapper()
@@ -495,7 +496,7 @@ object ExecutorInstrumentation {
     *
     * The instruments used to track the pool's behavior are removed once the pool is shut down.
     */
-  class InstrumentedScheduledThreadPoolExecutor(wrapped: ScheduledThreadPoolExecutor, name: String, extraTags: TagSet)
+  class InstrumentedScheduledThreadPoolExecutor(@BeanProperty override val wrapped: ScheduledThreadPoolExecutor, name: String, extraTags: TagSet)
       extends InstrumentedThreadPool(wrapped, name, extraTags, NoExtraSettings) with ScheduledExecutorService {
 
     override protected def executorType: String =
@@ -523,7 +524,7 @@ object ExecutorInstrumentation {
     *
     * The instruments used to track the pool's behavior are removed once the pool is shut down.
     */
-  class InstrumentedForkJoinPool(wrapped: ExecutorService, telemetryReader: ForkJoinPoolTelemetryReader, name: String,
+  class InstrumentedForkJoinPool(@BeanProperty val wrapped: ExecutorService, telemetryReader: ForkJoinPoolTelemetryReader, name: String,
       extraTags: TagSet, settings: Settings) extends ExecutorService {
 
     private val _runableWrapper = buildRunnableWrapper()


### PR DESCRIPTION
Having access to the underlying thread pools can be useful. This is
especially important because the instrumented classes do not extend the
class they wrap.

I would prefer to extend the classes they're wrapping, but unfortunately `ThreadPoolExecutor` and its sister classes are not interfaces. One option could be to use proxy objects, but that may be heavy handed.

We could also simply extend the wrapped classes, but we would have to override every single public method to call the wrapped counterpart. The downside is that it would break if `ThreadPoolExecutor` or others every changed their public interface.

Fixes #17