### PR TITLE
Fix ordering issue with reference.conf resolution

### DIFF
--- a/kamon-executors/src/main/resources/reference.conf
+++ b/kamon-executors/src/main/resources/reference.conf
@@ -21,7 +21,7 @@ kanela.modules {
       "kamon.instrumentation.executor.ExecutorTaskInstrumentation"
     ]
 
-    within = [ ]
+    within += [ ]
 
     exclude = [
       "^java.*",


### PR DESCRIPTION
If both kamon-executors and kamon-jdbc are used, then the "absolute" `within =` attribute in kamon-executors's reference.conf can cause problems due to the indeterministic order of resolution. 
Changed to a "relative" `within += `. 