### PR TITLE
fix errors thrown when trying to unwrap an unknown ExecutionContext implementation

### DIFF
--- a/kamon-executors/src/test/scala/kamon/instrumentation/executor/ExecutorsRegistrationSpec.scala
+++ b/kamon-executors/src/test/scala/kamon/instrumentation/executor/ExecutorsRegistrationSpec.scala
@@ -64,6 +64,12 @@ class ExecutorsRegistrationSpec extends WordSpec with Matchers with MetricInspec
       assertDoesNotContainAllExecutorNames(QueueSize.tagValues("name"))
 
     }
+
+    "not fail when an unknown ExecutionContext implementation is provided" in {
+      val ec = new WrappingExecutionContext(ExecutionContext.global)
+      val registered = ExecutorInstrumentation.instrumentExecutionContext(ec, "unknown-execution-context")
+      ThreadsActive.tagValues("name") shouldNot contain("unknown-execution-context")
+    }
   }
 
   def assertContainsAllExecutorNames(names: Seq[String]) = {
@@ -92,5 +98,10 @@ class ExecutorsRegistrationSpec extends WordSpec with Matchers with MetricInspec
       "unconfigurable-scheduled-thread-pool",
       "execution-context"
     )
+  }
+
+  class WrappingExecutionContext(ec: ExecutionContext) extends ExecutionContext {
+    override def execute(runnable: Runnable): Unit = ec.execute(runnable)
+    override def reportFailure(cause: Throwable): Unit = ec.reportFailure(cause)
   }
 }


### PR DESCRIPTION
This class makes the instrumentation safely ignore unsupported `ExecutionContext` implementations rather than throwing errors when trying to unwrap them. There was one incompatible change that had to be introduced with this: the return type of `.instrumentExecutionContext` changed to be `InstrumentedExecutionContext` (previously was `ExecutionContextExecutorService`). 

The reason why we had `ExecutionContextExecutorService` in the first place was to allow for a `shutdown` method that could de-register all metrics related to the executor but since `ExecutionContext` doesn't provide a shutdown method we opted for providing a more specific interface, without taking into account that it might happen that `.instrumentExecutionContext` gets called with an `ExecutionContext` for which we can't extract the underlying executor service.